### PR TITLE
bugfix: state accepting numbers & percentage display issues

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/AddPartnerForm.tsx
+++ b/src/components/AddPartnerForm.tsx
@@ -24,6 +24,12 @@ import "@mantine/dates/styles.css";
 
 const countries = ["United States", "Canada"];
 const DEFAULT_COUNTRY = "United States";
+const states = [
+  "MA", "AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "DC", "FL", "GA", "HI", 
+  "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD", "MI", "MN", "MS", "MO", 
+  "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", 
+  "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY",
+];
 
 type AddressFields = {
   addressLine: string;
@@ -74,7 +80,7 @@ export default function AddPartnerForm({
       setIsLoadingCities(true);
       try {
         const res = await fetch(
-          "http://api.geonames.org/searchJSON?q=&adminCode1=MA&country=US&featureClass=P&username=jumbocodebbdb",
+          "https://secure.geonames.org/searchJSON?q=&adminCode1=MA&country=US&featureClass=P&username=jumbocodebbdb",
         );
         const data = await res.json();
 
@@ -118,7 +124,20 @@ export default function AddPartnerForm({
       organization: (value) =>
         typeof value === "string" ? null : "Organization name must be a string",
       time: (value) => (value ? null : "Select a start time"),
-      cities: (value) => (value.length > 0 ? null : "Pick at least one city"),
+      cities: (value, values) => {
+        if (value.length === 0) return "Pick at least one city";
+        console.log(values.status);
+        if (values.status && values.status !== 'waitlisted') {
+          const total = value.reduce((sum, city) => {
+            return sum + (percentages[city] || 0);
+          }, 0);
+          const roundedTotal = Math.round(total * 100) / 100;
+          if (Math.abs(roundedTotal - 100) > 0.01) {
+            return `Percentages must add up to 100% (currently ${roundedTotal.toFixed(2)}%)`;
+          }
+        }
+        return null;        
+      },
       latitude: requiredNumber("Latitude"),
       longitude: requiredNumber("Longitude"),
       state: (value) =>
@@ -143,7 +162,8 @@ export default function AddPartnerForm({
     setIsSubmitting(true);
     const cityPercentages = values.cities.map((city) => {
       const raw = Number(percentages[city] ?? 0);
-      const normalized = Number.isFinite(raw) ? raw / 100 : 0;
+      // rounds percentages to avoid floating-point errors
+      const normalized = Number.isFinite(raw) ? Number((raw / 100).toFixed(4)) : 0;
       return { city, percentage: normalized };
     });
 
@@ -321,9 +341,18 @@ export default function AddPartnerForm({
                             suffix="%"
                             value={percentages[city] || ""}
                             onChange={(value) => {
+                              let res = 0;
+                              /* decimal percentages can have up to 2 decimal places */
+                              if (typeof value === "number") {
+                                res = value;
+                                const decimalPart = value.toString().split('.')[1];
+                                if (decimalPart && decimalPart.length > 2) {
+                                  res = Math.round(value * 100) / 100;
+                                }
+                              }
                               setPercentages((prev) => ({
                                 ...prev,
-                                [city]: typeof value === "number" ? value : 0,
+                                [city]: res,
                               }));
                             }}
                           />
@@ -424,14 +453,22 @@ export default function AddPartnerForm({
                   radius="md"
                   required
                 />
-                <TextInput
+                <Select
+                  placeholder="State"
+                  data={states}
+                  clearable
+                  size="md"
+                  radius="md"
+                  required 
+                />
+                {/*<TextInput
                   placeholder="State"
                   key={form.key("state")}
                   {...form.getInputProps("state")}
                   size="md"
                   radius="md"
                   required
-                />
+                /> */}
 
                 <TextInput
                   placeholder="Zip Code"

--- a/src/components/admin/PartnerTable.tsx
+++ b/src/components/admin/PartnerTable.tsx
@@ -42,6 +42,20 @@ function joinCoords(coords: { lat: number; lng: number }) {
   return `${roundCoords(coords).lat}, ${roundCoords(coords).lng}`;
 }
 
+function formatDate(rawDate: string) {
+  const date = new Date(rawDate);
+
+  if (isNaN(date.getTime())) {
+    return "Invalid Date";
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(date);
+}
+
 function formatPercentDisplay(value: number | null | undefined) {
   if (value == null) return null;
   const rounded = Number((value * 100).toFixed(4)); // round to 4 decimal places, drop trailing zeros
@@ -130,7 +144,7 @@ export default function PartnerTable({
                   </Table.Td>
                   <Table.Td className="text-sm text-gray-600">
                     {partner.start_partner ? (
-                      new Date(partner.start_partner).toLocaleDateString()
+                      formatDate(partner.start_partner)
                     ) : (
                       <span className="text-gray-400 italic">N/A</span>
                     )}
@@ -138,26 +152,15 @@ export default function PartnerTable({
                   <Table.Td>
                     <span key={partner.id} className="text-sm text-gray-600">
                       <span>
-                        {percentages
-                          .filter(
-                            (percentage) =>
-                              Number(percentage.partnerId) == partner.id,
-                          )
-                          .map((percentage, index, arr) => {
-                            const displayPct = formatPercentDisplay(
-                              percentage.percentage,
-                            );
-                            if (displayPct) {
-                              return (
-                                percentage.city.name +
-                                " (" +
-                                displayPct +
-                                ")" +
-                                (index != arr.length - 1 ? ", " : "")
-                              );
-                            }
-                            return null;
-                          })}
+                        {/* percentages for waitlisted orgs are optional and 
+                          won't be displayed for now */}
+                        { percentages
+                            .filter((percentage) => Number(percentage.partnerId) === partner.id)
+                            .map((p) => partner.status !== 'waitlisted' ? 
+                              `${p.city.name} (${formatPercentDisplay(p.percentage)})` 
+                              : p.city.name)
+                            .join(', ')
+                        }
                       </span>
                     </span>
                   </Table.Td>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
## Describe your changes

Found & fixed bugs for the add partner form @LotuAZ 

## Issue ticket number and link

#92 

## Files changed

- `AddPartnerForm.tsx`: 
    1) Added a list of states for users to pick, so that bad input like numbers are not accepted. 
    2) Fixed the geonames API by replacing the original endpoint with a secure endpoint that supports HTTPS requests
    3) Made sure that for non-waitlisted organizations, the city percentages cannot have > 2 decimal places and should add up to 100

- `PartnerTable.tsx`: 
    1) Date is now displayed in MM-YYYY format and not the exact date
    2) Waitlisted organizations do not have any city percentages displayed (previously it was shown as 0%)

## How to test

For the percentage check, we tried multiple cases including but not limited to: percentages with 3 or more decimal places, percentages that do not add up to 100, percentages that do add up to 100 but have 0/1/2 (varying) decimal places. 
The geonames API is not yet being tested in a production environment (the deployed server on vercel.app). We weren't sure how to do that, so right now we can only guarantee that it works as expected on localhost, curl, and postman.

## Checklist before requesting a review

- [OK] Implements all parts of the ticket
- [OK] Tested thoroughly
- [OK] No unused dependencies
- [OK] Requested review from Cooper