### PR TITLE
fix animations to work in production build

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,3 +19,46 @@ body {
 .leaflet-container .leaflet-popup-content p {
   margin: 0 !important;
 }
+
+.custom-map-tooltip {
+  background: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+}
+
+.custom-map-tooltip .leaflet-tooltip-left::before,
+.custom-map-tooltip .leaflet-tooltip-right::before,
+.custom-map-tooltip .leaflet-tooltip-top::before,
+.custom-map-tooltip .leaflet-tooltip-bottom::before {
+  display: none !important;
+}
+
+@keyframes cityBoundaryFadeIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+.city-boundary-enter {
+  animation: cityBoundaryFadeIn 700ms ease-out;
+}
+
+.city-boundary {
+  transition:
+    fill 300ms ease-out,
+    fill-opacity 300ms ease-out,
+    stroke 300ms ease-out,
+    stroke-width 300ms ease-out,
+    stroke-opacity 300ms ease-out,
+    filter 300ms ease-out;
+}
+
+.city-boundary:hover {
+  filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.4));
+  z-index: 1000;
+}

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -260,10 +260,12 @@ export default function Map({
           return (
             <Polygon
               key={boundaryId}
-              pathOptions={{
-                className: isEntering
+              className={
+                isEntering
                   ? "city-boundary city-boundary-enter"
-                  : "city-boundary",
+                  : "city-boundary"
+              }
+              pathOptions={{
                 weight:
                   activeId === boundary.id
                     ? 2
@@ -468,50 +470,6 @@ export default function Map({
         </Group>
       </Box>
 
-      <style jsx global>{`
-        .custom-map-tooltip {
-          background: transparent !important;
-          border: none !important;
-          box-shadow: none !important;
-          padding: 0 !important;
-        }
-
-        .custom-map-tooltip .leaflet-tooltip-left::before,
-        .custom-map-tooltip .leaflet-tooltip-right::before,
-        .custom-map-tooltip .leaflet-tooltip-top::before,
-        .custom-map-tooltip .leaflet-tooltip-bottom::before {
-          display: none !important;
-        }
-
-        @keyframes cityBoundaryFadeIn {
-          from {
-            opacity: 0;
-          }
-          to {
-            opacity: 1;
-          }
-        }
-
-        .city-boundary-enter {
-          animation: cityBoundaryFadeIn 700ms ease-out;
-        }
-
-        .city-boundary {
-          transition:
-            fill 300ms ease-out,
-            fill-opacity 300ms ease-out,
-            stroke 300ms ease-out,
-            stroke-width 300ms ease-out,
-            stroke-opacity 300ms ease-out,
-            filter 300ms ease-out;
-        }
-
-        .city-boundary:hover {
-          filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.4));
-          z-index: 1000;
-        }
-
-      `}</style>
     </div>
   );
 }


### PR DESCRIPTION
## Describe your changes

Fixed the production map animation issue where boundary animations stopped working after `npm run build` and `npm run start`. The Leaflet polygon classes were being passed through `pathOptions`, which meant the SVG paths never received the animation classes in production, so the CSS could not apply.

## Issue ticket number and link

No ticket provided.

## Files changed

- `src/components/map/Map.tsx`: Moved the polygon animation class onto the `Polygon` component itself so Leaflet applies it to the rendered SVG path.
- `src/app/globals.css`: Moved the map animation and tooltip styles into global CSS so they load consistently in the production build.

## How to test

Build and run the app in production mode:

- Run `npm run build`
- Run `npm run start`
- Open the home page map
- Click the timeline controls to move between years
- Confirm city boundaries animate in and transition smoothly in production
- Confirm tooltip styling still looks correct on hover

## Checklist before requesting a review

- [x] Implements all parts of the ticket
- [x] Tested thoroughly
- [x] No unused dependencies
- [x] Requested review from Cooper