### PR TITLE
Anna/hello rachel

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,23 +1,26 @@
+import RequestAwareClerkProvider from "@/components/auth/RequestAwareClerkProvider";
 import Profile from "@/components/admin/Profile";
 import { AppShell, AppShellHeader, AppShellMain, Group, Text } from "@mantine/core";
 import Link from "next/link";
 
 export default async function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <AppShell padding="md" header={{ height: 64 }}>
-      <AppShellHeader px="md">
-        <Group h="100%" justify="space-between">
-          <Text fw={700} c="blue.9">
-            Beantown Baby Admin
-          </Text>
+    <RequestAwareClerkProvider>
+      <AppShell padding="md" header={{ height: 64 }}>
+        <AppShellHeader px="md">
+          <Group h="100%" justify="space-between">
+            <Text fw={700} c="blue.9">
+              Beantown Baby Admin
+            </Text>
 
-          <Group gap="xs">
-            <Link href="/">View Map</Link>
-            <Profile />
+            <Group gap="xs">
+              <Link href="/">View Map</Link>
+              <Profile />
+            </Group>
           </Group>
-        </Group>
-      </AppShellHeader>
-      <AppShellMain>{children}</AppShellMain>
-    </AppShell>
+        </AppShellHeader>
+        <AppShellMain>{children}</AppShellMain>
+      </AppShell>
+    </RequestAwareClerkProvider>
   );
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -18,6 +18,7 @@ import { MonthPickerInput } from "@mantine/dates";
 import { useState, useEffect, useCallback, useMemo } from "react";
 import Image from "next/image";
 import { Poppins } from "next/font/google";
+import { useUser } from "@clerk/nextjs";
 import DistributionsTable from "@/components/admin/DistributionsTable";
 import { useDisclosure } from "@mantine/hooks";
 import UploadNewData from "../../components/admin/UploadDistributionDataForm";
@@ -105,8 +106,20 @@ const statuses = (Object.values(status) as string[]).map((s) => ({
   label: s.charAt(0).toUpperCase() + s.slice(1),
 }));
 
+function getGreetingName(user: ReturnType<typeof useUser>["user"]) {
+  if (user?.username) return user.username;
+
+  const email =
+    user?.primaryEmailAddress?.emailAddress ?? user?.emailAddresses?.[0]?.emailAddress;
+  if (!email) return "there";
+
+  return email.split("@")[0] || "there";
+}
+
 export default function Page() {
+  const { user } = useUser();
   const hashToTab = (hash: string): string => (hash === "#diapers" ? "Diapers" : "Partners");
+  const greetingName = getGreetingName(user);
 
   const [activeTab, setActiveTab] = useState<string | null>("Partners");
 
@@ -384,7 +397,7 @@ export default function Page() {
           <Card p={0}>
             <Group justify="space-between" align="flex-start">
               <Stack gap={4}>
-                <Title order={2}>Hello, Rachel 👋</Title>
+                <Title order={2}>Hello, {greetingName} 👋</Title>
                 <Group gap="xl" wrap="wrap">
                   <Text size="sm" c="dimmed">
                     Last data uploaded: {lastUploaded ?? "N/A"}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,6 @@
 import type { Metadata } from "next";
-import { Suspense } from "react";
-import { MantineProvider, Skeleton } from "@mantine/core";
+import { MantineProvider } from "@mantine/core";
 import { ModalsProvider } from "@mantine/modals";
-import { ClerkProvider } from "@clerk/nextjs";
 import "@mantine/core/styles.css";
 import "./globals.css";
 import "leaflet/dist/leaflet.css";
@@ -22,9 +20,7 @@ export default function RootLayout({
       <body>
         <MantineProvider>
           <ModalsProvider>
-            <Suspense fallback={<Skeleton />}>
-              <ClerkProvider>{children}</ClerkProvider>
-            </Suspense>
+            {children}
           </ModalsProvider>
         </MantineProvider>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { connection } from "next/server";
 import { Suspense } from "react";
 import { MantineProvider, Skeleton } from "@mantine/core";
 import { ModalsProvider } from "@mantine/modals";
@@ -12,11 +13,13 @@ export const metadata: Metadata = {
   description: "Providing diapers to families in need.",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  await connection();
+
   return (
     <html lang="en">
       <body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { connection } from "next/server";
 import { Suspense } from "react";
 import { MantineProvider, Skeleton } from "@mantine/core";
 import { ModalsProvider } from "@mantine/modals";
@@ -13,13 +12,11 @@ export const metadata: Metadata = {
   description: "Providing diapers to families in need.",
 };
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  await connection();
-
   return (
     <html lang="en">
       <body>

--- a/src/app/sign-in/[[...sign-in]]/SignInPageClient.tsx
+++ b/src/app/sign-in/[[...sign-in]]/SignInPageClient.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useSignIn } from "@clerk/nextjs";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import {
+  TextInput,
+  PasswordInput,
+  Button,
+  Paper,
+  Title,
+  Container,
+  Stack,
+  Center,
+  Text,
+  Checkbox,
+  Group,
+  Anchor,
+} from "@mantine/core";
+
+export default function SignInPageClient() {
+  const { isLoaded, signIn, setActive } = useSignIn();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isLoaded) return;
+
+    setLoading(true);
+    try {
+      const result = await signIn.create({
+        identifier: email,
+        password,
+      });
+
+      if (result.status === "complete") {
+        await setActive({ session: result.createdSessionId });
+        router.push("/admin");
+      }
+    } catch (err: any) {
+      console.error("Sign-in error:", err.errors[0].message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Center style={{ height: "100vh", backgroundColor: "#f8f9fa" }}>
+      <Container size={460} w="100%">
+        <Stack align="center" mb="xl">
+          <Image
+            src="/beantown-logo.svg"
+            alt="Beantown Baby Diaper Bank"
+            width={300}
+            height={80}
+            style={{ objectFit: "contain" }}
+          />
+        </Stack>
+
+        <Paper withBorder shadow="sm" p={40} radius="lg">
+          <Stack align="center" gap={4} mb="xl">
+            <Title order={2} fw={700}>
+              Welcome !
+            </Title>
+            <Text c="dimmed" size="sm">
+              Please enter your details.
+            </Text>
+          </Stack>
+
+          <form onSubmit={handleSubmit}>
+            <Stack gap="md">
+              <TextInput
+                label="Email address"
+                placeholder="Email address"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                radius="md"
+                size="md"
+              />
+              <PasswordInput
+                label="Password"
+                placeholder="Password"
+                required
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                radius="md"
+                size="md"
+              />
+
+              <Group justify="space-between" mt="xs">
+                <Checkbox label="Remember me" size="sm" />
+                <Anchor href="#" size="sm" fw={600} c="blue.7">
+                  Forgot password?
+                </Anchor>
+              </Group>
+
+              <Button
+                type="submit"
+                fullWidth
+                loading={loading}
+                color="blue.3"
+                radius="md"
+                size="md"
+                mt="md"
+              >
+                Sign In
+              </Button>
+            </Stack>
+          </form>
+        </Paper>
+      </Container>
+    </Center>
+  );
+}

--- a/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,119 +1,17 @@
-"use client";
+import { Suspense } from "react";
+import { connection } from "next/server";
+import { Skeleton } from "@mantine/core";
+import SignInPageClient from "./SignInPageClient";
 
-import { useSignIn } from "@clerk/nextjs";
-import { useState } from "react";
-import { useRouter } from "next/navigation";
-import Image from "next/image";
-import {
-  TextInput,
-  PasswordInput,
-  Button,
-  Paper,
-  Title,
-  Container,
-  Stack,
-  Center,
-  Text,
-  Checkbox,
-  Group,
-  Anchor,
-} from "@mantine/core";
+async function SignInPageContent() {
+  await connection();
+  return <SignInPageClient />;
+}
 
-export default function SignInPage() {
-  const { isLoaded, signIn, setActive } = useSignIn();
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [loading, setLoading] = useState(false);
-  const router = useRouter();
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!isLoaded) return;
-
-    setLoading(true);
-    try {
-      const result = await signIn.create({
-        identifier: email,
-        password,
-      });
-
-      if (result.status === "complete") {
-        await setActive({ session: result.createdSessionId });
-        router.push("/admin");
-      }
-    } catch (err: any) {
-      console.error("Sign-in error:", err.errors[0].message);
-    } finally {
-      setLoading(false);
-    }
-  };
-
+export default function Page() {
   return (
-    <Center style={{ height: "100vh", backgroundColor: "#f8f9fa" }}>
-      <Container size={460} w="100%">
-        <Stack align="center" mb="xl">
-          <Image
-            src="/beantown-logo.svg"
-            alt="Beantown Baby Diaper Bank"
-            width={300}
-            height={80}
-            style={{ objectFit: "contain" }}
-          />
-        </Stack>
-
-        <Paper withBorder shadow="sm" p={40} radius="lg">
-          <Stack align="center" gap={4} mb="xl">
-            <Title order={2} fw={700}>
-              Welcome !
-            </Title>
-            <Text c="dimmed" size="sm">
-              Please enter your details.
-            </Text>
-          </Stack>
-
-          <form onSubmit={handleSubmit}>
-            <Stack gap="md">
-              <TextInput
-                label="Email address"
-                placeholder="Email address"
-                required
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                radius="md"
-                size="md"
-              />
-              <PasswordInput
-                label="Password"
-                placeholder="Password"
-                required
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                radius="md"
-                size="md"
-              />
-
-              <Group justify="space-between" mt="xs">
-                <Checkbox label="Remember me" size="sm" />
-                <Anchor href="#" size="sm" fw={600} c="blue.7">
-                  Forgot password?
-                </Anchor>
-              </Group>
-
-              <Button
-                type="submit"
-                fullWidth
-                loading={loading}
-                color="blue.3"
-                radius="md"
-                size="md"
-                mt="md"
-              >
-                Sign In
-              </Button>
-            </Stack>
-          </form>
-        </Paper>
-      </Container>
-    </Center>
+    <Suspense fallback={<Skeleton height="100vh" />}>
+      <SignInPageContent />
+    </Suspense>
   );
 }

--- a/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,17 +1,10 @@
-import { Suspense } from "react";
-import { connection } from "next/server";
-import { Skeleton } from "@mantine/core";
+import RequestAwareClerkProvider from "@/components/auth/RequestAwareClerkProvider";
 import SignInPageClient from "./SignInPageClient";
-
-async function SignInPageContent() {
-  await connection();
-  return <SignInPageClient />;
-}
 
 export default function Page() {
   return (
-    <Suspense fallback={<Skeleton height="100vh" />}>
-      <SignInPageContent />
-    </Suspense>
+    <RequestAwareClerkProvider>
+      <SignInPageClient />
+    </RequestAwareClerkProvider>
   );
 }

--- a/src/app/unauthorized/layout.tsx
+++ b/src/app/unauthorized/layout.tsx
@@ -1,0 +1,9 @@
+import RequestAwareClerkProvider from "@/components/auth/RequestAwareClerkProvider";
+
+export default function UnauthorizedLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <RequestAwareClerkProvider>{children}</RequestAwareClerkProvider>;
+}

--- a/src/components/auth/RequestAwareClerkProvider.tsx
+++ b/src/components/auth/RequestAwareClerkProvider.tsx
@@ -1,0 +1,27 @@
+import { Suspense } from "react";
+import { connection } from "next/server";
+import { ClerkProvider } from "@clerk/nextjs";
+import { Skeleton } from "@mantine/core";
+
+async function RequestAwareClerkProviderContent({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  await connection();
+  return <ClerkProvider>{children}</ClerkProvider>;
+}
+
+export default function RequestAwareClerkProvider({
+  children,
+  fallback,
+}: {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}) {
+  return (
+    <Suspense fallback={fallback ?? <Skeleton height="100vh" />}>
+      <RequestAwareClerkProviderContent>{children}</RequestAwareClerkProviderContent>
+    </Suspense>
+  );
+}


### PR DESCRIPTION
## Describe your changes

Replaced the hardcoded "Hello Rachel" on the admin homepage with the current user's username/email (if present)

## Issue ticket number and link

See Notion

## Files changed

The app uses Next 16 with Cache Components enabled, so rendering `<ClerkProvider />` on the sign-in route caused Next to detect request-time behavior during pre-render. At first I tried to fix it by adding `await connection()` to the root layout, but that introduced another error ("Uncached data was accessed outside of `<Suspense>`"), since the entire app tree is now dynamic and that unrelated routes like `/demo` are failing pre-rendering. The final solution was to make request time rendering local to the sign-in route (see below).

- `src/app/sign-in/[[...sign-in]]/page.tsx`: a server-side component that wraps the sign-in entry point, `await connection()` gets called here.
- `src/app/sign-in/[[...sign-in]]/SignInPageClient.tsx`: a client component containing the sign-in UI.
- `src/app/admin/page.tsx`: fetches current user information (email, username) using Clerk's `useUser()` and renders the user's username as greeting. If username doesn't exist, the part before `@` in the user email will be rendered. `Hello there` is used as the last resort.

## How to test

Run `npm run dev` and log into the admin page with a valid clerk account. For example, if the user email is `E2Etest@test.com`, the admin page would render `Hello, e2etest 👋`

## Checklist before requesting a review

- [ ] Implements all parts of the ticket
- [ ] Tested thoroughly
- [ ] No unused dependencies
- [ ] Requested review from Cooper
